### PR TITLE
feat: simple smtc metadata cache.

### DIFF
--- a/LemonLite/App.xaml.Host.cs
+++ b/LemonLite/App.xaml.Host.cs
@@ -45,6 +45,7 @@ public partial class App
                                                             .AddConfig<AudioVisualizerConfig>()
                                                             .AddConfig<SmtcMetadataAliasConfig>()
                                                             .AddConfig<HotkeyConfig>()
+                                                            .AddConfig<SmtcMetadataCache>(Utils.Settings.sType.Cache)
                                                             .Init());
         services.AddHostedService(p => p.GetRequiredService<SmtcService>());
         services.AddHostedService(p => p.GetRequiredService<GlobalHotkeyService>());

--- a/LemonLite/Configs/SmtcMetadataCache.cs
+++ b/LemonLite/Configs/SmtcMetadataCache.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+
+namespace LemonLite.Configs;
+
+public class SmtcMetadataCacheEntry
+{
+    public string Title { get; init; } = string.Empty;
+    public string[] Artists { get; init; } = [];
+    public string Album { get; init; } = string.Empty;
+    public int DurationMs { get; init; }
+
+    /// <summary>
+    /// 每个sourceId对应一个歌词文件ID，sourceId来自<see cref="LemonLite.Sources.ILyricSource"/>
+    /// </summary>
+    public Dictionary<string, string> LyricFileIds { get; init; } = [];
+}
+
+public class SmtcMetadataCache
+{
+    public Dictionary<string, SmtcMetadataCacheEntry> Cache { get; } = [];
+}

--- a/LemonLite/Configs/SmtcMetadataCache.cs
+++ b/LemonLite/Configs/SmtcMetadataCache.cs
@@ -17,5 +17,5 @@ public class SmtcMetadataCacheEntry
 
 public class SmtcMetadataCache
 {
-    public Dictionary<string, SmtcMetadataCacheEntry> Cache { get; } = [];
+    public Dictionary<string, SmtcMetadataCacheEntry> Cache { get; set; } = [];
 }

--- a/LemonLite/Services/LyricService.cs
+++ b/LemonLite/Services/LyricService.cs
@@ -1,10 +1,12 @@
 using LemonLite.Configs;
 using LemonLite.Entities;
+using LemonLite.Sources;
 using LemonLite.Utils;
 using Lyricify.Lyrics.Models;
 using Lyricify.Lyrics.Searchers.Helpers;
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -34,11 +36,13 @@ public class LyricService
 {
     private readonly SmtcService _smtcService;
     private readonly SettingsMgr<AppOption> _appOption;
+    private readonly SettingsMgr<SmtcMetadataCache> _metadataCache;
 
     public LyricService(SmtcService smtcService, AppSettingService appSettingService)
     {
         _smtcService = smtcService;
         _appOption = appSettingService.GetConfigMgr<AppOption>();
+        _metadataCache= appSettingService.GetConfigMgr<SmtcMetadataCache>();
         _smtcService.SmtcListener.MediaPropertiesChanged += OnMediaPropertiesChanged;
         _smtcService.SmtcListener.SessionChanged += OnMediaPropertiesChanged;
         _smtcService.PositionChanged += OnPositionChanged;
@@ -152,17 +156,59 @@ public class LyricService
         try
         {
             var sources = _appOption.Data.GetSearchSources(mediaId);
+            if (sources is not { Count: > 0 }) sources = LyricSourceRegistry.DefaultSourceIds;
+            MusicMetaData? musicMetaData = null;
 
-            //retry with or without Album or duration metadata.
-            var searchResult = await LyricHelper.SearchMusicAsync(info.Title, info.Artist, info.Album, durationMs, sources, CompareHelper.MatchType.PrettyHigh, cancellationToken);
-            if (cancellationToken.IsCancellationRequested) return;
-            searchResult ??= await LyricHelper.SearchMusicAsync(info.Title, info.Artist, info.Album, null, sources, CompareHelper.MatchType.Medium, cancellationToken);
-            if (cancellationToken.IsCancellationRequested) return;
-            searchResult ??= await LyricHelper.SearchMusicAsync(info.Title, info.Artist, null, durationMs, sources, CompareHelper.MatchType.Medium, cancellationToken);
-            if (cancellationToken.IsCancellationRequested) return;
-            searchResult ??= await LyricHelper.SearchMusicAsync(info.Title, info.Artist, null, null, sources, CompareHelper.MatchType.Medium, cancellationToken);
+            //check metadata cache first
+            var cacheKey = $"{info.Title}_{info.Artist}_{info.Album}";
+            if (_metadataCache.Data.Cache.TryGetValue(cacheKey, out var cachedMeta) && cachedMeta is { Title: not null, LyricFileIds.Count: > 0 })
+            {
+                //only the first source preference is checked in cache.
+                var src = sources[0];
+                if (cachedMeta.LyricFileIds.TryGetValue(src, out var lyricId) && !string.IsNullOrEmpty(lyricId))
+                {
+                    var searcher = LyricSourceRegistry.Get(src)?.CreateSearcher();
+                    musicMetaData = new MusicMetaData
+                    {
+                        Title = cachedMeta.Title,
+                        Artists = cachedMeta.Artists,
+                        Album = cachedMeta.Album,
+                        DurationMs = cachedMeta.DurationMs,
+                        Id = lyricId,
+                        Searcher = searcher
+                    };
+                }
+            }
+            
+            if(musicMetaData == null) 
+            {
+                //retry with or without Album or duration metadata.
+                var searchResult = await LyricHelper.SearchMusicAsync(info.Title, info.Artist, info.Album, durationMs, sources, CompareHelper.MatchType.PrettyHigh, cancellationToken);
+                if (cancellationToken.IsCancellationRequested) return;
+                searchResult ??= await LyricHelper.SearchMusicAsync(info.Title, info.Artist, info.Album, null, sources, CompareHelper.MatchType.Medium, cancellationToken);
+                if (cancellationToken.IsCancellationRequested) return;
+                searchResult ??= await LyricHelper.SearchMusicAsync(info.Title, info.Artist, null, durationMs, sources, CompareHelper.MatchType.Medium, cancellationToken);
+                if (cancellationToken.IsCancellationRequested) return;
+                searchResult ??= await LyricHelper.SearchMusicAsync(info.Title, info.Artist, null, null, sources, CompareHelper.MatchType.Medium, cancellationToken);
+                musicMetaData = searchResult;
 
-            if (searchResult is { Id: not null } musicMetaData)
+                if(searchResult is { Id: not null ,Title: not null, Artists: not null})
+                {
+                    //record cache
+                    cachedMeta ??= new SmtcMetadataCacheEntry()
+                    {
+                        Title = searchResult.Title,
+                        Artists = searchResult.Artists,
+                        Album = searchResult.Album ?? "",
+                        DurationMs = searchResult.DurationMs,
+                        LyricFileIds = []
+                    };
+                    cachedMeta.LyricFileIds[searchResult.Searcher?.Name?.ToLower()??"unknown"] = searchResult.Id;
+                    _metadataCache.Data.Cache[cacheKey] = cachedMeta;
+                }
+            }
+
+            if (musicMetaData is { Id: not null })
             {
                 if (cancellationToken.IsCancellationRequested) return;
 

--- a/LemonLite/Views/Pages/AppSettingsPage.xaml.cs
+++ b/LemonLite/Views/Pages/AppSettingsPage.xaml.cs
@@ -25,12 +25,19 @@ namespace LemonLite.Views.Pages
             InitializeComponent();
             DataContext = this;
             Loaded += AppSettingsPage_Loaded;
+            Unloaded += AppSettingsPage_Unloaded;
             settings=appSettingService.GetConfigMgr<AppOption>();
             appearanceSettings=appSettingService.GetConfigMgr<Appearance>();
             hotkeySettings=appSettingService.GetConfigMgr<HotkeyConfig>();
             _hotkeyService = hotkeyService;
             ColorMode = appearanceSettings.Data.ColorMode;
             smtc = smtcService;
+        }
+
+        private void AppSettingsPage_Unloaded(object sender, RoutedEventArgs e)
+        {
+            var localizationService = LocalizationService.Instance;
+            localizationService.LanguageChanged -= OnLanguageChanged;
         }
 
         private void AppSettingsPage_Loaded(object sender, RoutedEventArgs e)
@@ -59,6 +66,7 @@ namespace LemonLite.Views.Pages
         {
             OnPropertyChanged(nameof(IsEnglishLanguage));
             OnPropertyChanged(nameof(IsChineseLanguage));
+            UpdateConflictStates();
         }
 
         [ObservableProperty]

--- a/LemonLite/Views/UserControls/HotkeyRecorder.xaml
+++ b/LemonLite/Views/UserControls/HotkeyRecorder.xaml
@@ -12,8 +12,8 @@
              LostFocus="HotkeyRecorder_LostFocus"
              mc:Ignorable="d">
     <Border x:Name="RootBorder"
-            MinWidth="160"
             Height="32"
+            MinWidth="160"
             Background="{DynamicResource MaskColor}"
             BorderBrush="{DynamicResource BorderColor}"
             BorderThickness="1"


### PR DESCRIPTION
A simple SMTC metadata cache：
For each entry in cache, the key is claimed as $"{info.Title}_{info.Artist}_{info.Album}", and a simple metadata is stored. Plus, an entry contains a dict[sourceId, lyricFileId], which is designed to provide a multi-platform support. However, the cached key varies from different platforms……